### PR TITLE
require axis on coordinate vars

### DIFF
--- a/ch07.adoc
+++ b/ch07.adoc
@@ -678,6 +678,7 @@ For example, polygon geometries could include single part geometries like the St
 
 The **`node_coordinates`** attribute contains the blank-separated names of the variables that contain geometry node coordinates (one variable for each spatial dimension). 
 The geometry node coordinate variables must each have an **`axis`** attribute whose allowable values are __X__, __Y__, and __Z__. 
+If a **`coordinates`** attribute is carried by the geometry container variable, then those coordinate variables which correspond to node coordinate variables must also have the **`axis`** attribute.
 The geometry node coordinate variables must all have the same single dimension, which is the total number of nodes in all the geometries. 
 The nodes must be stored consecutively for each geometry and in the order of the geometries, and within each multipart geometry the nodes must be stored consecutively for each part and in the order of the parts. 
 Polygon exterior rings must be put in anticlockwise order (viewed from above) and polygon interior rings in clockwise order. 
@@ -735,10 +736,12 @@ variables:
     lat:units = "degrees_north" ;
     lat:standard_name = "latitude" ;
     lat:geometry = "geometry_container" ;
+    lat:axis = "Y" ;
   double lon(instance) ;
     lon:units = "degrees_east" ;
     lon:standard_name = "longitude" ;
     lon:geometry = "geometry_container" ;
+    lon:axis = "X" ;
   float geometry_container ;
     geometry_container:geometry_type = "polygon" ;
     geometry_container:node_count = "node_count" ;

--- a/history.adoc
+++ b/history.adoc
@@ -180,3 +180,6 @@ Replaced first para in Section 9.6. "Missing Data". Added verbiage to Section 2.
 
 .13 December 2017
 . Ticket #164, Implement suggestions from trac ticket comments.
+
+.24 January 2018
+. Ticket #164, If coordinates attribute is carried by geometry container, require coordinate variables which correspond to node coordinate variables to have the corresponding axis attribute.


### PR DESCRIPTION
If coordinates attribute is carried by geometry container, require coordinate variables which correspond to node coordinate variables to have the corresponding axis attribute.

See http://cf-trac.llnl.gov/trac/ticket/164

 - [ ] Added link from trac ticket to this PR?

 > Applied via ​https://github.com/cf-convention/cf-conventions/pull/115

 - [ ] Updated "Revision History"? (Use the date you applied the changes.)
